### PR TITLE
PKCE (S256) e escopo content.write no fluxo OAuth

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,9 +23,11 @@ passport.use(
       clientID: process.env.CLIENT_ID,
       clientSecret: process.env.CLIENT_SECRET,
       callbackURL: process.env.CALLBACK_URL || `http://localhost:8080/callback`,
-      scope: "openid email content.read offline_access",
+      scope: "openid email content.read content.write offline_access",
       prompt: "consent",
       scopeSeparator: " ",
+      state: true,
+      pkce: true,
     },
     (accessToken, refreshToken, profile, cb) => {
       profile.accessToken = accessToken;

--- a/routes/index.js
+++ b/routes/index.js
@@ -41,7 +41,8 @@ router.get('/callback', function(req, res, next) {
         const response = await axios.get(`${OLDDRAGON_BASE_URL}/campanhas.json`, {
           headers: {
             Authorization: `Bearer ${req.user.accessToken}`,
-            'User-Agent': 'OldDragon-Example-App',
+            'User-Agent': 'OldDragon-Example-App (contact: oi@olddragon.com.br)',
+            Accept: 'application/json',
           },
         });
         


### PR DESCRIPTION
olddragon.com.br passou a exigir PKCE (S256) no authorization code flow. Ativa pkce/state no passport-oauth2 (que gera e valida o code_verifier via sessão), adiciona o escopo content.write e os cabeçalhos Accept/User-Agent recomendados pela API. Após o merge, é necessário rodar o deploy no Fly (fly deploy ou o workflow com FLY_API_TOKEN).