### PR TITLE
UI somente em português e README.en.md dedicado

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,120 @@
+# Old Dragon API — Node.js Demo
+
+🇧🇷 [Versão em português](README.md)
+
+Example Express application (built with express-generator) demonstrating how to
+integrate with the [Old Dragon API](https://github.com/olddragoneditora/olddragon-api)
+using OAuth 2.0 + PKCE: login, reading user data, and one write.
+
+You can use the live app at
+[olddragon-api-nodejs-demo.fly.dev](https://olddragon-api-nodejs-demo.fly.dev) —
+or fork this project and adapt it to your own application, deploying it
+yourself (see "Deploy" below).
+
+## What this demo shows
+
+- **OAuth 2.0 login with PKCE (S256)** — the standard authorization code flow
+  for a web app (confidential client, `client_secret` never reaches the
+  browser), no device flow needed.
+- **Reads (`content.read`)**: lists the authenticated user's campaigns
+  (`GET /campanhas.json`) and characters (`GET /personagens.json`), and shows a
+  character's detail page (`GET /personagens/:id.json`).
+- **Write (`content.write`)**: a form on the character page sends
+  `PATCH /personagens/:id.json` to update current HP.
+- **Token refresh**: on a plain 401 (expired token), the app exchanges the
+  refresh token for a new access token and retries the call once before
+  giving up and sending the user back to `/login`. A 401 for insufficient
+  scope (`insufficient_scope`) is never treated as an expired token — it's
+  shown as an on-screen error message instead.
+
+## Features
+
+- OAuth 2.0 authentication with PKCE
+- Campaign and character listing + detail
+- Updating a character's HP (a write to the API)
+- Portuguese UI using EJS templates (the app's screens are Portuguese-only;
+  this README is the English reference)
+
+## Requirements
+
+- Node.js 24 or higher (current LTS)
+- An Old Dragon account (olddragon.com.br)
+- OAuth application Client ID and Client Secret
+
+## Getting OAuth credentials
+
+Register your application at
+[olddragon.com.br/conta/aplicativos](https://olddragon.com.br/conta/aplicativos)
+(self-service, no manual approval needed). Request the `openid`, `email`,
+`content.read`, `content.write` and `offline_access` scopes, and provide the
+callback URL (`http://localhost:8080/callback` for local development).
+
+More details at [github.com/olddragoneditora/olddragon-api](https://github.com/olddragoneditora/olddragon-api).
+
+## Scopes used
+
+| Scope | Usage |
+|---|---|
+| `openid`, `email` | Identifies the logged-in user |
+| `content.read` | Required for every read (`GET`): campaigns, characters |
+| `content.write` | Required for the HP update (`PATCH`) |
+| `offline_access` | Issues a refresh token so the access token can be renewed without a new login |
+
+## Running locally
+
+1. Clone this project
+2. Install dependencies: `npm install`
+3. Set the environment variables:
+
+```bash
+export CLIENT_ID="your_client_id"
+export CLIENT_SECRET="your_client_secret"
+export SESSION_SECRET="your_session_secret_key"
+export CALLBACK_URL="http://localhost:8080/callback"
+```
+
+4. Run: `npm start`
+5. Open: http://localhost:8080
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `CLIENT_ID` | Old Dragon OAuth application ID |
+| `CLIENT_SECRET` | Old Dragon OAuth application secret |
+| `SESSION_SECRET` | Session signing secret |
+| `CALLBACK_URL` | OAuth callback URL (e.g. `http://localhost:8080/callback`) |
+| `OLDDRAGON_BASE_URL` | Optional, defaults to `https://olddragon.com.br` — useful to point at another environment |
+| `PORT` | Optional, defaults to `8080` |
+
+## Deploy
+
+Deployment runs on [Fly.io](https://fly.io) via GitHub Actions
+(`.github/workflows/fly-deploy.yml`), triggered on every push to `main` (or
+manually from the Actions tab, via `workflow_dispatch`). You need to set the
+`FLY_API_TOKEN` secret in the repository settings.
+
+To deploy your own copy:
+
+```sh
+fly launch
+fly secrets set CLIENT_ID="your_client_id"
+fly secrets set CLIENT_SECRET="your_client_secret"
+fly secrets set CALLBACK_URL="https://your-app.fly.dev/callback"
+fly secrets set SESSION_SECRET="make_up_a_random_secret_key_here"
+fly deploy
+```
+
+**Note**: the app uses `express-session`'s default in-memory session store.
+That's fine for this demo (single machine, only holds short-lived OAuth
+tokens), but it doesn't scale across multiple instances — a real production
+app should use a persistent store (Redis, Postgres, etc).
+
+## Structure
+
+- `app.js`: Main Express setup and the OAuth2 strategy
+- `lib/oldDragonApi.js`: Standard headers and the request wrapper with token refresh
+- `routes/index.js`: Home, login, callback, logout
+- `routes/personagens.js`: Character listing, detail, and HP update
+- `views/`: EJS templates (Portuguese-only UI)
+- `bin/www`: Server startup script

--- a/README.md
+++ b/README.md
@@ -1,66 +1,46 @@
-# Old Dragon API — Demo Node.js / Node.js Demo
+# Old Dragon API — Demo Node.js
+
+🇬🇧 [English version](README.en.md)
 
 Exemplo de aplicação Express (criada com o express-generator) que demonstra como
 integrar com a [API do Old Dragon](https://github.com/olddragoneditora/olddragon-api)
 usando OAuth 2.0 + PKCE: login, leitura de dados do usuário e uma escrita.
-
-Example Express application (built with express-generator) demonstrating how to
-integrate with the [Old Dragon API](https://github.com/olddragoneditora/olddragon-api)
-using OAuth 2.0 + PKCE: login, reading user data, and one write.
 
 Você pode acessar a aplicação em produção em
 [olddragon-api-nodejs-demo.fly.dev](https://olddragon-api-nodejs-demo.fly.dev) —
 ou fazer _fork_ deste projeto e adaptá-lo para a sua própria aplicação, fazendo
 deploy você mesmo (veja "Deploy" abaixo).
 
-You can use the live app at
-[olddragon-api-nodejs-demo.fly.dev](https://olddragon-api-nodejs-demo.fly.dev) —
-or fork this project and adapt it to your own application, deploying it
-yourself (see "Deploy" below).
-
-## O que este demo mostra / What this demo shows
+## O que este demo mostra
 
 - **Login via OAuth 2.0 com PKCE (S256)** — fluxo padrão de authorization code
   em uma aplicação web (client confidencial, `client_secret` fica só no
   servidor), sem precisar de device flow.
-  **OAuth 2.0 login with PKCE (S256)** — the standard authorization code flow
-  for a web app (confidential client, `client_secret` never reaches the
-  browser), no device flow needed.
 - **Leitura (`content.read`)**: lista as campanhas (`GET /campanhas.json`) e os
   personagens (`GET /personagens.json`) do usuário autenticado, e mostra o
   detalhe de um personagem (`GET /personagens/:id.json`).
-  **Reads (`content.read`)**: lists the authenticated user's campaigns
-  (`GET /campanhas.json`) and characters (`GET /personagens.json`), and shows a
-  character's detail page (`GET /personagens/:id.json`).
 - **Escrita (`content.write`)**: um formulário na página do personagem faz
   `PATCH /personagens/:id.json` para atualizar os PV atuais.
-  **Write (`content.write`)**: a form on the character page sends
-  `PATCH /personagens/:id.json` to update current HP.
 - **Renovação de token**: em um 401 comum (token expirado), a aplicação troca o
   refresh token por um novo access token e repete a chamada uma vez antes de
   desistir e mandar o usuário de volta para `/login`. Um 401 por escopo
   insuficiente (`insufficient_scope`) nunca é tratado como token expirado — é
   mostrado como mensagem de erro na tela.
-  **Token refresh**: on a plain 401 (expired token), the app exchanges the
-  refresh token for a new access token and retries the call once before
-  giving up and sending the user back to `/login`. A 401 for insufficient
-  scope (`insufficient_scope`) is never treated as an expired token — it's
-  shown as an on-screen error message instead.
 
-## Funcionalidades / Features
+## Funcionalidades
 
-- Autenticação OAuth 2.0 com PKCE / OAuth 2.0 authentication with PKCE
-- Listagem e detalhe de campanhas e personagens / Campaign and character listing + detail
-- Atualização de PV de um personagem (escrita na API) / Updating a character's HP (a write to the API)
-- Interface bilíngue (PT/EN) usando templates EJS / Bilingual (PT/EN) UI using EJS templates
+- Autenticação OAuth 2.0 com PKCE
+- Listagem e detalhe de campanhas e personagens
+- Atualização de PV de um personagem (escrita na API)
+- Interface em português usando templates EJS
 
-## Requisitos / Requirements
+## Requisitos
 
-- Node.js 24 ou superior (LTS atual) / Node.js 24 or higher (current LTS)
-- Conta no Old Dragon (olddragon.com.br) / An Old Dragon account (olddragon.com.br)
-- Client ID e Client Secret de uma aplicação OAuth / OAuth application Client ID and Client Secret
+- Node.js 24 ou superior (LTS atual)
+- Conta no Old Dragon (olddragon.com.br)
+- Client ID e Client Secret de uma aplicação OAuth
 
-## Como obter credenciais OAuth / Getting OAuth credentials
+## Como obter credenciais OAuth
 
 Cadastre sua aplicação em
 [olddragon.com.br/conta/aplicativos](https://olddragon.com.br/conta/aplicativos)
@@ -68,29 +48,22 @@ Cadastre sua aplicação em
 `email`, `content.read`, `content.write` e `offline_access`, e informe a URL de
 callback (`http://localhost:8080/callback` em desenvolvimento).
 
-Register your application at
-[olddragon.com.br/conta/aplicativos](https://olddragon.com.br/conta/aplicativos)
-(self-service, no manual approval needed). Request the `openid`, `email`,
-`content.read`, `content.write` and `offline_access` scopes, and provide the
-callback URL (`http://localhost:8080/callback` for local development).
-
 Mais detalhes em [github.com/olddragoneditora/olddragon-api](https://github.com/olddragoneditora/olddragon-api).
-More details at [github.com/olddragoneditora/olddragon-api](https://github.com/olddragoneditora/olddragon-api).
 
-## Escopos usados / Scopes used
+## Escopos usados
 
-| Escopo / Scope | Uso / Usage |
+| Escopo | Uso |
 |---|---|
-| `openid`, `email` | Identifica o usuário logado / Identifies the logged-in user |
-| `content.read` | Exigido em toda leitura (`GET`): campanhas, personagens / Required for every read (`GET`): campaigns, characters |
-| `content.write` | Exigido para a atualização de PV (`PATCH`) / Required for the HP update (`PATCH`) |
-| `offline_access` | Emite um refresh token para renovar o access token sem novo login / Issues a refresh token so the access token can be renewed without a new login |
+| `openid`, `email` | Identifica o usuário logado |
+| `content.read` | Exigido em toda leitura (`GET`): campanhas, personagens |
+| `content.write` | Exigido para a atualização de PV (`PATCH`) |
+| `offline_access` | Emite um refresh token para renovar o access token sem novo login |
 
-## Rodando localmente / Running locally
+## Rodando localmente
 
-1. Clone este projeto / Clone this project
-2. Instale as dependências / Install dependencies: `npm install`
-3. Configure as variáveis de ambiente / Set the environment variables:
+1. Clone este projeto
+2. Instale as dependências: `npm install`
+3. Configure as variáveis de ambiente:
 
 ```bash
 export CLIENT_ID="seu_client_id"
@@ -99,19 +72,19 @@ export SESSION_SECRET="sua_chave_secreta_sessao"
 export CALLBACK_URL="http://localhost:8080/callback"
 ```
 
-4. Execute / Run: `npm start`
-5. Acesse / Open: http://localhost:8080
+4. Execute: `npm start`
+5. Acesse: http://localhost:8080
 
-## Variáveis de Ambiente / Environment Variables
+## Variáveis de Ambiente
 
-| Variável / Variable | Descrição / Description |
+| Variável | Descrição |
 |---|---|
-| `CLIENT_ID` | ID da aplicação OAuth do Old Dragon / Old Dragon OAuth application ID |
-| `CLIENT_SECRET` | Secret da aplicação OAuth do Old Dragon / Old Dragon OAuth application secret |
-| `SESSION_SECRET` | Chave secreta para sessões / Session signing secret |
-| `CALLBACK_URL` | URL de callback OAuth (ex: `http://localhost:8080/callback`) / OAuth callback URL |
-| `OLDDRAGON_BASE_URL` | Opcional, padrão `https://olddragon.com.br` — útil para apontar para outro ambiente / Optional, defaults to `https://olddragon.com.br` — useful to point at another environment |
-| `PORT` | Opcional, padrão `8080` / Optional, defaults to `8080` |
+| `CLIENT_ID` | ID da aplicação OAuth do Old Dragon |
+| `CLIENT_SECRET` | Secret da aplicação OAuth do Old Dragon |
+| `SESSION_SECRET` | Chave secreta para sessões |
+| `CALLBACK_URL` | URL de callback OAuth (ex: `http://localhost:8080/callback`) |
+| `OLDDRAGON_BASE_URL` | Opcional, padrão `https://olddragon.com.br` — útil para apontar para outro ambiente |
+| `PORT` | Opcional, padrão `8080` |
 
 ## Deploy
 
@@ -120,12 +93,7 @@ O deploy é feito no [Fly.io](https://fly.io) via GitHub Actions
 (ou manualmente pela aba Actions, via `workflow_dispatch`). É preciso
 configurar o secret `FLY_API_TOKEN` nas configurações do repositório.
 
-Deployment runs on [Fly.io](https://fly.io) via GitHub Actions
-(`.github/workflows/fly-deploy.yml`), triggered on every push to `main` (or
-manually from the Actions tab, via `workflow_dispatch`). You need to set the
-`FLY_API_TOKEN` secret in the repository settings.
-
-Para fazer deploy da sua própria cópia / To deploy your own copy:
+Para fazer deploy da sua própria cópia:
 
 ```sh
 fly launch
@@ -141,16 +109,11 @@ fly deploy
 tokens OAuth de curta duração), mas não escala para múltiplas instâncias — um
 app real de produção deve usar um store persistente (Redis, Postgres, etc).
 
-**Note**: the app uses `express-session`'s default in-memory session store.
-That's fine for this demo (single machine, only holds short-lived OAuth
-tokens), but it doesn't scale across multiple instances — a real production
-app should use a persistent store (Redis, Postgres, etc).
+## Estrutura
 
-## Estrutura / Structure
-
-- `app.js`: Configuração principal do Express e da estratégia OAuth2 / Main Express setup and the OAuth2 strategy
-- `lib/oldDragonApi.js`: Cabeçalhos padrão e o wrapper de requisição com renovação de token / Standard headers and the request wrapper with token refresh
-- `routes/index.js`: Home, login, callback, logout / Home, login, callback, logout
-- `routes/personagens.js`: Listagem, detalhe e atualização de PV de personagens / Character listing, detail, and HP update
-- `views/`: Templates EJS / EJS templates
-- `bin/www`: Script de inicialização do servidor / Server startup script
+- `app.js`: Configuração principal do Express e da estratégia OAuth2
+- `lib/oldDragonApi.js`: Cabeçalhos padrão e o wrapper de requisição com renovação de token
+- `routes/index.js`: Home, login, callback, logout
+- `routes/personagens.js`: Listagem, detalhe e atualização de PV de personagens
+- `views/`: Templates EJS
+- `bin/www`: Script de inicialização do servidor

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -18,3 +18,8 @@ a {
   background: #f8d7da;
   color: #721c24;
 }
+
+.lang-note {
+  font-size: 12px;
+  opacity: 0.7;
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,9 +5,9 @@ var router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-  res.render('index', { 
-    title: 'Old Dragon API Example',
-    user: req.user 
+  res.render('index', {
+    title: 'Exemplo da API do Old Dragon',
+    user: req.user
   });
 });
 
@@ -20,7 +20,7 @@ router.get('/callback', function(req, res, next) {
     if (err) {
       console.error('Authentication Error:', err);
       return res.render('error', {
-        message: 'Erro de Autenticação / Authentication Error',
+        message: 'Erro de Autenticação',
         error: { status: 500, stack: err.message },
         user: req.user
       });
@@ -41,7 +41,7 @@ router.get('/callback', function(req, res, next) {
         const response = await apiRequest(req, { method: 'get', url: `${OLDDRAGON_BASE_URL}/campanhas.json` });
 
         res.render('success', {
-          title: 'Autenticação Realizada / Authentication Successful',
+          title: 'Autenticação Realizada',
           user: req.user,
           accessToken: req.user.accessToken,
           campanhas: response.data
@@ -50,7 +50,7 @@ router.get('/callback', function(req, res, next) {
         if (error instanceof NeedsLoginError) return redirectToLogin(req, res);
         console.error('Error fetching campanhas:', error.message);
         res.render('error', {
-          message: 'Erro ao Buscar Dados / Error Fetching Data',
+          message: 'Erro ao Buscar Dados',
           error: { status: error.response?.status || 500, stack: error.message },
           user: req.user
         });

--- a/routes/personagens.js
+++ b/routes/personagens.js
@@ -14,12 +14,12 @@ router.use(ensureAuthenticated);
 router.get('/', async function (req, res) {
   try {
     const response = await apiRequest(req, { method: 'get', url: `${OLDDRAGON_BASE_URL}/personagens.json` });
-    res.render('personagens/index', { title: 'Personagens / Characters', personagens: response.data, user: req.user });
+    res.render('personagens/index', { title: 'Personagens', personagens: response.data, user: req.user });
   } catch (error) {
     if (error instanceof NeedsLoginError) return redirectToLogin(req, res);
     console.error('Erro ao buscar personagens:', error.message);
     res.render('error', {
-      message: 'Erro ao Buscar Personagens / Error Fetching Characters',
+      message: 'Erro ao Buscar Personagens',
       error: { status: error.response?.status || 500, stack: error.message },
       user: req.user,
     });
@@ -45,7 +45,7 @@ router.get('/:id', async function (req, res) {
     if (error instanceof NeedsLoginError) return redirectToLogin(req, res);
     console.error('Erro ao buscar personagem:', error.message);
     res.render('error', {
-      message: 'Erro ao Buscar Personagem / Error Fetching Character',
+      message: 'Erro ao Buscar Personagem',
       error: { status: error.response?.status || 500, stack: error.message },
       user: req.user,
     });
@@ -68,8 +68,8 @@ router.post('/:id/pv', async function (req, res) {
     if (error instanceof NeedsLoginError) return redirectToLogin(req, res);
 
     const pvError = isInsufficientScope(error)
-      ? 'Seu token não tem a permissão "content.write" necessária para esta ação. / Your token lacks the "content.write" permission needed for this action.'
-      : `Erro ao atualizar PV (HTTP ${error.response?.status || '?'}). / Error updating HP (HTTP ${error.response?.status || '?'}).`;
+      ? 'Seu token não tem a permissão "content.write" necessária para esta ação.'
+      : `Erro ao atualizar PV (HTTP ${error.response?.status || '?'}).`;
 
     // Re-fetch the character so the page renders normally alongside the error banner.
     try {
@@ -88,7 +88,7 @@ router.post('/:id/pv', async function (req, res) {
       if (fetchError instanceof NeedsLoginError) return redirectToLogin(req, res);
       console.error('Erro ao buscar personagem após falha no PATCH:', fetchError.message);
       return res.render('error', {
-        message: 'Erro ao Atualizar PV / Error Updating HP',
+        message: 'Erro ao Atualizar PV',
         error: { status: error.response?.status || 500, stack: error.message },
         user: req.user,
       });

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -12,6 +12,6 @@
     <h2><%= error.status %></h2>
     <pre><%= error.stack %></pre>
 
-    <p><a href="/">Voltar / Back</a></p>
+    <p><a href="/">Voltar</a></p>
   </body>
 </html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -10,15 +10,14 @@
 
     <h1><%= title %></h1>
     <p>
-      Exemplo de integração com a API do Old Dragon usando OAuth 2.0 (login, personagens, campanhas).<br>
-      Example integration with the Old Dragon API using OAuth 2.0 (login, characters, campaigns).
+      Exemplo de integração com a API do Old Dragon usando OAuth 2.0 (login, personagens, campanhas).
     </p>
 
     <% if (typeof user !== 'undefined' && user) { %>
-      <p>Usuário autenticado! / You're logged in!</p>
-      <p><a href="/personagens">Ver meus personagens / See my characters</a></p>
+      <p>Usuário autenticado!</p>
+      <p><a href="/personagens">Ver meus personagens</a></p>
     <% } else { %>
-      <a href="/login">Login com Old Dragon / Login with Old Dragon</a>
+      <a href="/login">Entrar com Old Dragon</a>
     <% } %>
   </body>
 </html>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -1,9 +1,10 @@
 <nav>
-  <a href="/">Início / Home</a>
+  <a href="/">Início</a>
   <% if (typeof user !== 'undefined' && user) { %>
-    | <a href="/personagens">Personagens / Characters</a>
-    | <a href="/logout">Sair / Logout</a>
+    | <a href="/personagens">Personagens</a>
+    | <a href="/logout">Sair</a>
   <% } else { %>
-    | <a href="/login">Entrar / Login</a>
+    | <a href="/login">Entrar</a>
   <% } %>
 </nav>
+<p class="lang-note">🇬🇧 <a href="https://github.com/olddragoneditora/olddragon-api-nodejs-demo/blob/main/README.en.md">Documentation in English: README.en.md</a></p>

--- a/views/personagens/index.ejs
+++ b/views/personagens/index.ejs
@@ -8,24 +8,23 @@
   <body>
     <%- include('../partials/nav', { user }) %>
 
-    <h1>Personagens / Characters</h1>
+    <h1>Personagens</h1>
     <p>
-      Lista dos personagens do usuário autenticado (<code>GET /personagens.json</code>).<br>
-      List of the authenticated user's characters (<code>GET /personagens.json</code>).
+      Lista dos personagens do usuário autenticado (<code>GET /personagens.json</code>).
     </p>
 
     <% if (personagens.length === 0) { %>
-      <p>Nenhum personagem encontrado. / No characters found.</p>
+      <p>Nenhum personagem encontrado.</p>
     <% } else { %>
       <table>
         <thead>
           <tr>
-            <th>Nome / Name</th>
-            <th>Nível / Level</th>
-            <th>Classe / Class</th>
-            <th>Raça / Race</th>
-            <th>Campanha / Campaign</th>
-            <th>PV / HP</th>
+            <th>Nome</th>
+            <th>Nível</th>
+            <th>Classe</th>
+            <th>Raça</th>
+            <th>Campanha</th>
+            <th>PV</th>
           </tr>
         </thead>
         <tbody>

--- a/views/personagens/show.ejs
+++ b/views/personagens/show.ejs
@@ -8,44 +8,42 @@
   <body>
     <%- include('../partials/nav', { user }) %>
 
-    <p><a href="/personagens">&larr; Personagens / Characters</a></p>
+    <p><a href="/personagens">&larr; Personagens</a></p>
 
     <h1><%= personagem.name %></h1>
     <p>
-      Detalhe do personagem (<code>GET /personagens/<%= personagem.id %>.json</code>).<br>
-      Character detail (<code>GET /personagens/<%= personagem.id %>.json</code>).
+      Detalhe do personagem (<code>GET /personagens/<%= personagem.id %>.json</code>).
     </p>
 
     <ul>
-      <li>Nível / Level: <strong><%= personagem.level %></strong></li>
-      <li>Classe / Class: <strong><%= personagem.character_class?.name ?? "-" %></strong></li>
-      <li>Raça / Race: <strong><%= personagem.character_race?.name ?? "-" %></strong></li>
-      <li>Campanha / Campaign: <strong><%= personagem.campaign?.name ?? "-" %></strong></li>
-      <li>Classe de Armadura / Armor Class (CA): <strong><%= personagem.ac ?? "-" %></strong></li>
-      <li>Experiência / Experience (XP): <strong><%= personagem.experience_points ?? "-" %></strong></li>
-      <li>PV atual / total (HP current / max): <strong><%= personagem.max_hp != null ? `${personagem.health_points} / ${personagem.max_hp}` : "-" %></strong></li>
+      <li>Nível: <strong><%= personagem.level %></strong></li>
+      <li>Classe: <strong><%= personagem.character_class?.name ?? "-" %></strong></li>
+      <li>Raça: <strong><%= personagem.character_race?.name ?? "-" %></strong></li>
+      <li>Campanha: <strong><%= personagem.campaign?.name ?? "-" %></strong></li>
+      <li>Classe de Armadura (CA): <strong><%= personagem.ac ?? "-" %></strong></li>
+      <li>Experiência (XP): <strong><%= personagem.experience_points ?? "-" %></strong></li>
+      <li>PV atual / total: <strong><%= personagem.max_hp != null ? `${personagem.health_points} / ${personagem.max_hp}` : "-" %></strong></li>
     </ul>
 
     <% if (pvSuccess) { %>
-      <p class="notice">PV atualizado com sucesso! / HP updated successfully!</p>
+      <p class="notice">PV atualizado com sucesso!</p>
     <% } %>
     <% if (pvError) { %>
       <p class="notice notice-error"><%= pvError %></p>
     <% } %>
 
     <% if (personagem.max_hp != null) { %>
-    <h2>Atualizar PV / Update HP</h2>
+    <h2>Atualizar PV</h2>
     <p>
-      Envia um <code>PATCH /personagens/<%= personagem.id %>.json</code> para a API (requer o escopo <code>content.write</code>).<br>
-      Sends a <code>PATCH /personagens/<%= personagem.id %>.json</code> to the API (requires the <code>content.write</code> scope).
+      Envia um <code>PATCH /personagens/<%= personagem.id %>.json</code> para a API (requer o escopo <code>content.write</code>).
     </p>
     <form method="POST" action="/personagens/<%= personagem.id %>/pv">
-      <label for="health_points">PV atual / Current HP (0-<%= personagem.max_hp %>)</label>
+      <label for="health_points">PV atual (0-<%= personagem.max_hp %>)</label>
       <input type="number" id="health_points" name="health_points" min="0" max="<%= personagem.max_hp %>" value="<%= personagem.health_points %>" required>
-      <button type="submit">Atualizar / Update</button>
+      <button type="submit">Atualizar</button>
     </form>
     <% } else { %>
-      <p class="notice">Personagem ainda em criação — sem PV para atualizar. / Character still being created — no HP to update yet.</p>
+      <p class="notice">Personagem ainda em criação — sem PV para atualizar.</p>
     <% } %>
   </body>
 </html>

--- a/views/success.ejs
+++ b/views/success.ejs
@@ -10,12 +10,12 @@
 
     <h1><%= title %></h1>
 
-    <p><a href="/personagens">Ver meus personagens / See my characters</a></p>
+    <p><a href="/personagens">Ver meus personagens</a></p>
 
     <h2>Access Token</h2>
     <pre><%= accessToken %></pre>
 
-    <h2>Campanhas do Usuário / User's Campaigns</h2>
+    <h2>Campanhas do Usuário</h2>
     <pre><%= JSON.stringify(campanhas, null, 2) %></pre>
   </body>
 </html>


### PR DESCRIPTION
## Resumo

O app e o README misturavam português e inglês lado a lado em toda string
(ex.: "Personagens / Characters"), o que ficava poluído e difícil de ler.

- **README**: `README.md` fica só em português; criado `README.en.md` com a
  tradução completa da mesma estrutura. Cada um linka para o outro no topo.
- **Telas do app** (views EJS, partial de navegação, páginas de erro):
  removida toda a duplicação "/ Inglês" — títulos, cabeçalhos de tabela,
  labels, botões, avisos e texto de formulário agora são só em português. As
  menções a endpoints (`GET /personagens.json` etc.) foram mantidas como
  estavam.
- Adicionada uma linha discreta no nav compartilhado apontando para o
  `README.en.md` no GitHub — essa é toda a estratégia de inglês na UI, sem
  toggle de idioma nem framework de i18n.
- Revisado o português que sobrou nas views (estava escrito como metade de
  frase bilíngue) para ler bem sozinho.
